### PR TITLE
Use `params` instead of non-existent `query` for `href` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ import { href } from './router';
 
 const ProjectCard = (props: { id: string }) => {
 	return (
-		<Link to={href({ path: '/projects/:projectId', query: { projectId: props.id } })}>
+		<Link to={href({ path: '/projects/:projectId', params: { projectId: props.id } })}>
 			<p>Project {projectId}</p>
 		</Link>
 	);


### PR DESCRIPTION
The `params` parameter is defined in [browser-router.ts](https://github.com/fredericoo/react-router-typesafe/blob/4a216a10be91a4c073e16a65b106fd019b1b96d5/src/browser-router.ts#L43)