### PR TITLE
add options to typesafeBrowserRouter

### DIFF
--- a/src/__tests__/browser-router.test.ts
+++ b/src/__tests__/browser-router.test.ts
@@ -234,3 +234,13 @@ test('works with relative paths', () => {
 
 	expect(output).toEqual('/blog/asd/comments');
 });
+
+test('allows basename option', () => {
+	const { href } = typesafeBrowserRouter([{ path: '/' }], {
+		basename: '/app',
+	});
+
+	const output = href({ path: '/' });
+
+	expect(output).toEqual('/');
+});

--- a/src/browser-router.ts
+++ b/src/browser-router.ts
@@ -1,3 +1,4 @@
+import type { unstable_DataStrategyFunction, FutureConfig, HydrationState } from '@remix-run/router';
 import { RouteObject, createBrowserRouter } from 'react-router-dom';
 
 type Narrowable = string | number | bigint | boolean;
@@ -42,7 +43,15 @@ const joinValidWith =
 	(...valid: any[]) =>
 		valid.filter(Boolean).join(separator);
 
-export const typesafeBrowserRouter = <const R extends RouteObject>(routes: NarrowArray<R>) => {
+interface DOMRouterOpts {
+	basename?: string;
+	future?: Partial<Omit<FutureConfig, 'v7_prependBasename'>>;
+	hydrationData?: HydrationState;
+	unstable_dataStrategy?: unstable_DataStrategyFunction;
+	window?: Window;
+}
+
+export const typesafeBrowserRouter = <const R extends RouteObject>(routes: NarrowArray<R>, opts?: DOMRouterOpts) => {
 	type Paths = ExtractPaths<R, ''>;
 
 	function href<P extends Paths>(
@@ -65,7 +74,7 @@ export const typesafeBrowserRouter = <const R extends RouteObject>(routes: Narro
 	}
 
 	return {
-		router: createBrowserRouter(routes as RouteObject[]),
+		router: createBrowserRouter(routes as RouteObject[], opts),
 		href,
 	};
 };

--- a/src/browser-router.ts
+++ b/src/browser-router.ts
@@ -1,4 +1,3 @@
-import type { unstable_DataStrategyFunction, FutureConfig, HydrationState } from '@remix-run/router';
 import { RouteObject, createBrowserRouter } from 'react-router-dom';
 
 type Narrowable = string | number | bigint | boolean;
@@ -43,15 +42,9 @@ const joinValidWith =
 	(...valid: any[]) =>
 		valid.filter(Boolean).join(separator);
 
-interface DOMRouterOpts {
-	basename?: string;
-	future?: Partial<Omit<FutureConfig, 'v7_prependBasename'>>;
-	hydrationData?: HydrationState;
-	unstable_dataStrategy?: unstable_DataStrategyFunction;
-	window?: Window;
-}
+type OptionsType = typeof createBrowserRouter extends (routes: unknown, opts: infer OptsType) => any ? OptsType : never;
 
-export const typesafeBrowserRouter = <const R extends RouteObject>(routes: NarrowArray<R>, opts?: DOMRouterOpts) => {
+export const typesafeBrowserRouter = <const R extends RouteObject>(routes: NarrowArray<R>, opts?: OptionsType) => {
 	type Paths = ExtractPaths<R, ''>;
 
 	function href<P extends Paths>(


### PR DESCRIPTION
Hi,

I am missing the possibility to use the options on the browserRouter.

https://reactrouter.com/en/main/routers/create-browser-router

Sadly the `DOMRouterOpts` is not exported therefore I simply copied it with the types from base package. 
If you have a better solution for that, just let me know. 

I did not add any tests, cause I am not really familiar with testing-library. Just let me know how to test this. 